### PR TITLE
v0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,20 +27,19 @@ classifiers = [
 ]
 dependencies = [
     "ipywidgets",
-    "leidenalg",
+    "leidenalg<0.11",
     "markov_clustering",
     "matplotlib",
     "networkx",
     "nltk",
-    "numpy",
+    "numpy>=1.21",
     "openpyxl",
-    "pandas",
-    "python-igraph",
+    "pandas>=1.3",
+    "igraph>=0.11,<1.0",
     "python-louvain",
-    "scikit-learn",
+    "scikit-learn>=1.0",
     "scipy",
     "statsmodels",
-    "threadpoolctl",
     "tqdm",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy"]
+requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -27,7 +27,8 @@ classifiers = [
 ]
 dependencies = [
     "ipywidgets",
-    "leidenalg<0.11",
+    # Keep Leiden on 0.10.x until migration to igraph 1.x.
+    "leidenalg>=0.10,<0.11",
     "markov_clustering",
     "matplotlib",
     "networkx",
@@ -35,11 +36,13 @@ dependencies = [
     "numpy>=1.21",
     "openpyxl",
     "pandas>=1.3",
-    "igraph>=0.11,<1.0",
+    # Leiden 0.10.x depends on igraph <0.12.
+    "igraph>=0.11,<0.12",
     "python-louvain",
     "scikit-learn>=1.0",
     "scipy",
     "statsmodels",
+    "threadpoolctl>=3.1",
     "tqdm",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,18 @@
 ipywidgets
-leidenalg
+# Keep Leiden on 0.10.x until migration to igraph 1.x.
+leidenalg>=0.10,<0.11
 markov_clustering
 matplotlib
 networkx
 nltk
-numpy
+numpy>=1.21
 openpyxl
-pandas
-python-igraph
+pandas>=1.3
+# Leiden 0.10.x depends on igraph <0.12.
+igraph>=0.11,<0.12
 python-louvain
-scikit-learn
+scikit-learn>=1.0
 scipy
 statsmodels
-threadpoolctl
+threadpoolctl>=3.1
 tqdm

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -9,4 +9,4 @@ A next-generation tool for biological network annotation and visualization
 from .risk import RISK
 
 __all__ = ["RISK"]
-__version__ = "0.1.3a0"
+__version__ = "0.1.3"

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -9,4 +9,4 @@ A next-generation tool for biological network annotation and visualization
 from .risk import RISK
 
 __all__ = ["RISK"]
-__version__ = "0.1.2"
+__version__ = "0.1.3a0"

--- a/src/risk/annotation/annotation.py
+++ b/src/risk/annotation/annotation.py
@@ -341,10 +341,9 @@ def _calculate_jaccard_index(set1: Set[Any], set2: Set[Any]) -> float:
 
 def _generate_coherent_description(words: List[str]) -> str:
     """
-    Generate a coherent description from a list of words.
-
-    If there is only one unique entry, return it directly.
-    Otherwise, order the words by frequency and join them into a single string.
+    Generate a coherent description from a list of words. If there is only one unique entry,
+    return it directly; otherwise, order the words by frequency and join them into a single
+    string.
 
     Args:
         words (List[str]): A list of tokens.

--- a/src/risk/annotation/io.py
+++ b/src/risk/annotation/io.py
@@ -17,8 +17,9 @@ class AnnotationAPI:
     """
     Handles the loading and exporting of annotation in various file formats.
 
-    The AnnotationAPI class provides methods to load annotation from different file types (JSON, CSV, Excel, etc.)
-    and to export parameter data to various formats like JSON, CSV, and text files.
+    The AnnotationAPI class provides methods to load annotation from different file types
+    (JSON, CSV, Excel, etc.) and to export parameter data to various formats like JSON, CSV,
+    and text files.
     """
 
     def load_annotation_json(

--- a/src/risk/log/console.py
+++ b/src/risk/log/console.py
@@ -30,10 +30,10 @@ class MockLogger:
     """
     MockLogger: A lightweight logger replacement using print statements in Jupyter.
 
-    The MockLogger class replicates the behavior of a standard logger using print statements
-    to display messages. This is primarily used in a Jupyter environment to show outputs
-    directly in the notebook. The class supports logging levels such as `info`, `debug`,
-    `warning`, and `error`, while the `verbose` attribute controls whether to display non-error messages.
+    The MockLogger class replicates the behavior of a standard logger using print statements to
+    display messages. This is primarily used in a Jupyter environment to show outputs directly
+    in the notebook. The class supports logging levels such as `info`, `debug`, `warning`, and
+    `error`, while the `verbose` attribute controls whether to display non-error messages.
     """
 
     def __init__(self, verbose: bool = True):

--- a/src/risk/log/parameters.py
+++ b/src/risk/log/parameters.py
@@ -21,9 +21,9 @@ class Params:
     """
     Handles the storage and logging of various parameters for network analysis.
 
-    The Params class provides methods to log parameters related to different components of the analysis,
-    such as the network, annotation, clusters, graph, and plotter settings. It also stores
-    the current datetime when the parameters were initialized.
+    The Params class provides methods to log parameters related to different components of the
+    analysis, such as the network, annotation, clusters, graph, and plotter settings. It also
+    stores the current datetime when the parameters were initialized.
     """
 
     def __init__(self):

--- a/src/risk/network/graph/_summary.py
+++ b/src/risk/network/graph/_summary.py
@@ -16,10 +16,10 @@ class Summary:
     """
     Handles the processing, storage, and export of network analysis results.
 
-    The Summary class provides methods to process significance and depletion data,
-    compute FDR-corrected q-values, and structure information on domains and
-    annotations into a DataFrame. It also offers functionality to export the
-    processed data in CSV, JSON, and text formats for analysis and reporting.
+    The Summary class provides methods to process significance and depletion data, compute
+    FDR-corrected q-values, and structure information on domains and annotations into a DataFrame.
+    It also offers functionality to export the processed data in CSV, JSON, and text formats for
+    analysis and reporting.
     """
 
     _ANNOTATION_COLUMN = "Annotation"
@@ -77,6 +77,13 @@ class Summary:
         self.annotation = annotation
         self.stats_results = stats_results
         self.graph = graph
+        self._summary_cache = None
+
+    def clear_cache(self) -> None:
+        """
+        Clear the cached summary table. Use this when upstream internals are manually mutated outside Graph APIs.
+        """
+        self._summary_cache = None
 
     def to_csv(self, filepath: str) -> None:
         """
@@ -124,6 +131,10 @@ class Summary:
                 - Domain-conditioned p/q values (minimum p/q within nodes belonging to each domain)
         """
         log_header("Loading analysis summary")
+        if self._summary_cache is not None:
+            logger.debug("Returning cached analysis summary.")
+            return self._summary_cache.copy()
+
         ordered_annotation = tuple(self.annotation["ordered_annotation"])
         # Cache annotation -> matrix column index for constant-time lookups downstream.
         annotation_to_idx = {description: idx for idx, description in enumerate(ordered_annotation)}
@@ -151,18 +162,19 @@ class Summary:
             enrichment_qvals=enrichment_qvals,
             depletion_qvals=depletion_qvals,
         )
-        return self._merge_and_finalize_results(
+        results = self._merge_and_finalize_results(
             ordered_annotation=ordered_annotation_frame,
             raw_results=raw_results,
             domain_results=domain_results,
         )
+        self._summary_cache = results
+        return results.copy()
 
     def _build_annotation_members_map(self, annotation_to_idx: Dict[str, int]) -> Dict[str, str]:
         """
-        Precompute matched member labels for each annotation from the sparse matrix.
-
-        This method uses CSC column pointers to avoid repeated sparse-column slicing
-        and dense conversions when building summary rows.
+        Precompute matched member labels for each annotation from the sparse matrix. This method uses
+        CSC column pointers to avoid repeated sparse-column slicing and dense conversions when building
+        summary rows.
 
         Args:
             annotation_to_idx (Dict[str, int]): Mapping from annotation label to
@@ -197,10 +209,8 @@ class Summary:
         depletion_qvals: np.ndarray,
     ) -> pd.DataFrame:
         """
-        Build domain-conditioned rows used in the summary table.
-
-        For each annotation assigned to a domain label, domain-level p/q values are
-        computed as minima over nodes that belong to that domain.
+        Build domain-conditioned rows used in the summary table. For each annotation assigned to a domain
+        label, domain-level p/q values are computed as minima over nodes that belong to that domain.
 
         Args:
             annotation_to_idx (Dict[str, int]): Mapping from annotation label to

--- a/src/risk/network/graph/api.py
+++ b/src/risk/network/graph/api.py
@@ -24,7 +24,8 @@ class GraphAPI:
     """
     Handles the loading of network graphs and associated data.
 
-    The GraphAPI class provides methods to load and process network graphs, annotations, and cluster results.
+    The GraphAPI class provides methods to load and process network graphs, annotations, and
+    cluster results.
     """
 
     def load_graph(

--- a/src/risk/network/graph/graph.py
+++ b/src/risk/network/graph/graph.py
@@ -17,9 +17,9 @@ class Graph:
     """
     A class to represent a network graph and process its nodes and edges.
 
-    The Graph class provides functionality to handle and manipulate a network graph,
-    including managing domains, annotation, and node significance data. It also includes methods
-    for transforming and mapping graph coordinates, as well as generating colors based on node
+    The Graph class provides functionality to handle and manipulate a network graph, including
+    managing domains, annotation, and node significance data. It also includes methods for
+    transforming and mapping graph coordinates, as well as generating colors based on node
     significance.
     """
 
@@ -34,7 +34,6 @@ class Graph:
         node_significance_sums: np.ndarray,
     ):
         """
-
         Initialize the Graph object.
 
         Args:
@@ -80,6 +79,7 @@ class Graph:
     def pop(self, domain_id: int) -> List[str]:
         """
         Remove a domain ID from the graph and return the corresponding node labels.
+        Also invalidates cached summary output.
 
         Args:
             domain_id (int): The domain ID to remove from the cached domain mappings.
@@ -108,6 +108,7 @@ class Graph:
                 domain_info["domains"].remove(domain_id)
                 domain_info["significances"].pop(domain_id)
 
+        self.summary.clear_cache()
         return node_labels
 
     def _create_domain_id_to_node_ids_map(self, domains: pd.DataFrame) -> Dict[int, Any]:

--- a/src/risk/network/io.py
+++ b/src/risk/network/io.py
@@ -156,8 +156,9 @@ class NetworkIO:
     """
     A class for loading, processing, and managing network data.
 
-    The NetworkIO class provides methods to load network data from various formats (e.g., GPickle, NetworkX)
-    and process the network by adjusting node coordinates, calculating edge lengths, and validating graph structure.
+    The NetworkIO class provides methods to load network data from various formats (e.g., GPickle,
+    NetworkX) and process the network by adjusting node coordinates, calculating edge lengths, and
+    validating graph structure.
     """
 
     def __init__(

--- a/src/risk/network/plotter/_network.py
+++ b/src/risk/network/plotter/_network.py
@@ -17,7 +17,8 @@ class Network:
     """
     A class for plotting network graphs with customizable options.
 
-    The Network class provides methods to plot network graphs with flexible node and edge properties.
+    The Network class provides methods to plot network graphs with flexible node and edge
+    properties.
     """
 
     def __init__(self, graph: Graph, ax: Any = None):

--- a/src/risk/network/plotter/_plotter.py
+++ b/src/risk/network/plotter/_plotter.py
@@ -21,8 +21,8 @@ class Plotter(Canvas, Network, Contour, Labels):
     """
     A class for visualizing network graphs with customizable options.
 
-    The Plotter class uses a Graph object and provides methods to plot the network with
-    flexible node and edge properties. It also supports plotting labels, contours, drawing the network's
+    The Plotter class uses a Graph object and provides methods to plot the network with flexible
+    node and edge properties. It also supports plotting labels, contours, drawing the network's
     perimeter, and adjusting background colors.
     """
 

--- a/src/risk/network/plotter/api.py
+++ b/src/risk/network/plotter/api.py
@@ -16,7 +16,8 @@ class PlotterAPI:
     """
     Handles the loading of network plotter objects.
 
-    The PlotterAPI class provides methods to load and configure Plotter objects for plotting network graphs.
+    The PlotterAPI class provides methods to load and configure Plotter objects for plotting
+    network graphs.
     """
 
     def load_plotter(

--- a/tests/test_load_graph.py
+++ b/tests/test_load_graph.py
@@ -497,10 +497,9 @@ def test_load_graph_summary(graph):
 
 def test_summary_reports_raw_and_domain_pq(risk_obj, cytoscape_network, json_annotation):
     """
-    Ensure summary exposes both raw and domain-conditioned p/q values.
-
-    Raw values must remain invariant across linkage settings; domain-conditioned
-    values are derived as minima within each domain's node set.
+    Ensure summary exposes both raw and domain-conditioned p/q values. Raw values must remain
+    invariant across linkage settings; domain-conditioned values are derived as minima within each
+    domain's node set.
     """
     clusters = risk_obj.cluster_louvain(
         network=cytoscape_network,
@@ -596,6 +595,18 @@ def test_pop_domain(graph):
     Args:
         graph: The graph object instance with existing domain mappings.
     """
+    # Cache should be deterministic and caller-safe before graph mutation.
+    initial_summary = graph.summary.load()
+    cached_summary = graph.summary.load()
+    pd.testing.assert_frame_equal(
+        initial_summary,
+        cached_summary,
+        check_exact=False,
+        atol=1e-12,
+        rtol=0.0,
+    )
+    assert initial_summary is not cached_summary
+
     # Define the domain ID to be removed
     domain_id_to_remove = 1
     # Retrieve expected labels before popping
@@ -627,6 +638,10 @@ def test_pop_domain(graph):
         assert domain_id_to_remove not in domain_info.get(
             "significances", {}
         ), f"{domain_id_to_remove} should be removed from node_id_to_domain_ids_and_significance_map['significances']"
+
+    # Finally, check that the summary no longer contains the removed domain ID
+    refreshed_summary = graph.summary.load()
+    assert domain_id_to_remove not in set(refreshed_summary["Domain ID"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This release prepares RISK v0.1.3 for stable distribution. Dependency versions were updated and constrained in pyproject.toml to improve installation reliability across environments. A temporary alpha tag (0.1.3a0) was used to test deployment on a remote server before finalizing the release. Documentation and docstring formatting were cleaned up, and README sections were updated for clarity. Result summary loading now uses caching to reduce redundant work.