### PR TITLE
v0.1.5: Add node-domain provenance metadata

### DIFF
--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -9,4 +9,4 @@ A next-generation tool for biological network annotation and visualization
 from .risk import RISK
 
 __all__ = ["RISK"]
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/src/risk/cluster/label.py
+++ b/src/risk/cluster/label.py
@@ -4,7 +4,7 @@ risk/cluster/label
 """
 
 from itertools import product
-from typing import Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -37,7 +37,7 @@ def define_domains(
     linkage_method: str,
     linkage_metric: str,
     linkage_threshold: Union[float, str],
-) -> pd.DataFrame:
+) -> Tuple[pd.DataFrame, Dict[int, Dict[int, List[Tuple[int, str, float]]]]]:
     """
     Define domains and assign nodes to these domains based on their significance scores and clustering,
     handling errors by assigning unique domains when clustering fails.
@@ -51,7 +51,9 @@ def define_domains(
         linkage_threshold (float, str): The threshold for clustering. Choose "auto" to optimize.
 
     Returns:
-        pd.DataFrame: DataFrame with the primary domain for each node.
+        Tuple[pd.DataFrame, Dict[int, Dict[int, List[Tuple[int, str, float]]]]]:
+            - DataFrame with the primary domain for each node.
+            - Nonzero contributing terms per node and domain, sorted descending by absolute significance.
 
     Raises:
         ValueError: If any clustering argument is invalid.
@@ -151,6 +153,8 @@ def define_domains(
             names=["annotation", "domain"],
         ),
     )
+    # Capture nonzero contributing terms before domain-level summation collapses term identity
+    contributing_terms = _rank_contributing_terms(node_to_significance, top_annotation)
     node_to_domain = node_to_significance.T.groupby(level="domain").sum().T
 
     # Find the dominant domain per node using absolute significance:
@@ -167,7 +171,7 @@ def define_domains(
     # Assign primary domain
     node_to_domain["primary_domain"] = t_idxmax
 
-    return node_to_domain
+    return node_to_domain, contributing_terms
 
 
 def trim_domains(
@@ -244,6 +248,44 @@ def trim_domains(
         ~trimmed_domains_matrix.index.isin(invalid_domain_ids)
     ]
     return valid_domains, valid_trimmed_domains_matrix
+
+
+def _rank_contributing_terms(
+    node_to_significance: pd.DataFrame,
+    top_annotation: pd.DataFrame,
+) -> Dict[int, Dict[int, List[Tuple[int, str, float]]]]:
+    """
+    Rank each node's nonzero contributing annotation terms within each domain by masked significance.
+
+    Args:
+        node_to_significance (pd.DataFrame): Node-by-term significance matrix with a MultiIndex
+            (annotation, domain) column structure, prior to domain-level summation.
+        top_annotation (pd.DataFrame): Top annotation data, used to resolve annotation term
+            indices to their full term strings.
+
+    Returns:
+        Dict[int, Dict[int, List[Tuple[int, str, float]]]]: Mapping of node ID to domain ID to a
+            list of (term index, term string, masked significance) tuples with nonzero
+            significance, sorted descending by absolute significance.
+    """
+    contributing_terms: Dict[int, Dict[int, List[Tuple[int, str, float]]]] = {}
+    for domain_id, domain_group in node_to_significance.T.groupby(level="domain"):
+        term_indices = domain_group.index.get_level_values("annotation")
+        term_strings = top_annotation.loc[term_indices, "full_terms"].tolist()
+        for node_id, node_values in domain_group.items():
+            # Only nonzero terms actually contribute to this node's domain association
+            nonzero_terms = [
+                (term_idx, term_str, value)
+                for term_idx, term_str, value in zip(term_indices, term_strings, node_values)
+                if value != 0
+            ]
+            if not nonzero_terms:
+                continue
+            # Rank by magnitude so depletion (negative) signal sorts consistently with enrichment
+            nonzero_terms.sort(key=lambda term: abs(term[2]), reverse=True)
+            contributing_terms.setdefault(node_id, {})[int(domain_id)] = nonzero_terms
+
+    return contributing_terms
 
 
 def _validate_clustering_args(

--- a/src/risk/network/graph/_stats.py
+++ b/src/risk/network/graph/_stats.py
@@ -28,7 +28,8 @@ def calculate_significance_matrices(
 
     Returns:
         Dict[str, Any]: Dictionary containing the enrichment matrix, binary significance matrix,
-            and the matrix of significant enrichment values.
+            matrix of significant enrichment values, FDR-corrected q-value matrices, and the
+            enrichment/depletion selection mask.
     """
     if fdr_cutoff < 1.0:
         # Apply FDR correction to depletion p-values
@@ -52,11 +53,14 @@ def calculate_significance_matrices(
             depletion_pvals, pval_cutoff=pval_cutoff
         )
         depletion_matrix = depletion_pvals
+        # No FDR correction is applied in this mode, so no q-values exist to report
+        depletion_qvals = None
 
         enrichment_alpha_threshold_matrix = _compute_threshold_matrix(
             enrichment_pvals, pval_cutoff=pval_cutoff
         )
         enrichment_matrix = enrichment_pvals
+        enrichment_qvals = None
 
     # Floor exact zeros to avoid infinities from -log10(0) in downstream magnitude scaling.
     p_floor = np.finfo(float).eps
@@ -64,7 +68,11 @@ def calculate_significance_matrices(
     log_enrichment_matrix = -np.log10(np.clip(enrichment_matrix, p_floor, 1.0))
 
     # Select the appropriate significance matrices based on the specified tail
-    significance_matrix, significant_binary_significance_matrix = _select_significance_matrices(
+    (
+        significance_matrix,
+        significant_binary_significance_matrix,
+        enrichment_selection_matrix,
+    ) = _select_significance_matrices(
         tail,
         log_depletion_matrix,
         depletion_alpha_threshold_matrix,
@@ -81,6 +89,9 @@ def calculate_significance_matrices(
         "significance_matrix": significance_matrix,
         "significant_significance_matrix": significant_significance_matrix,
         "significant_binary_significance_matrix": significant_binary_significance_matrix,
+        "enrichment_qvals": enrichment_qvals,
+        "depletion_qvals": depletion_qvals,
+        "enrichment_selection_matrix": enrichment_selection_matrix,
     }
 
 
@@ -102,7 +113,9 @@ def _select_significance_matrices(
         enrichment_alpha_threshold_matrix (np.ndarray): Alpha threshold matrix for enrichment significance.
 
     Returns:
-        tuple: A tuple containing the selected enrichment matrix and binary significance matrix.
+        tuple: A tuple containing the selected enrichment matrix, binary significance matrix, and
+            a boolean mask indicating whether enrichment (True) or depletion (False) was selected
+            per cell.
 
     Raises:
         ValueError: If the provided tail type is not 'left', 'right', or 'both'.
@@ -114,17 +127,21 @@ def _select_significance_matrices(
         # Select depletion matrix and corresponding alpha threshold for left-tail analysis
         significance_matrix = -log_depletion_matrix
         alpha_threshold_matrix = depletion_alpha_threshold_matrix
+        enrichment_selection_matrix = np.zeros(log_depletion_matrix.shape, dtype=bool)
     elif tail == "right":
         # Select enrichment matrix and corresponding alpha threshold for right-tail analysis
         significance_matrix = log_enrichment_matrix
         alpha_threshold_matrix = enrichment_alpha_threshold_matrix
+        enrichment_selection_matrix = np.ones(log_enrichment_matrix.shape, dtype=bool)
     elif tail == "both":
         # Select the matrix with the highest absolute values while preserving the sign
+        depletion_selected = np.abs(log_depletion_matrix) >= np.abs(log_enrichment_matrix)
         significance_matrix = np.where(
-            np.abs(log_depletion_matrix) >= np.abs(log_enrichment_matrix),
+            depletion_selected,
             -log_depletion_matrix,
             log_enrichment_matrix,
         )
+        enrichment_selection_matrix = ~depletion_selected
         # Combine alpha thresholds using a logical OR operation
         alpha_threshold_matrix = np.logical_or(
             depletion_alpha_threshold_matrix, enrichment_alpha_threshold_matrix
@@ -137,7 +154,7 @@ def _select_significance_matrices(
     significant_binary_significance_matrix = np.zeros(alpha_threshold_matrix.shape)
     significant_binary_significance_matrix[valid_idxs] = alpha_threshold_matrix[valid_idxs]
 
-    return significance_matrix, significant_binary_significance_matrix
+    return significance_matrix, significant_binary_significance_matrix, enrichment_selection_matrix
 
 
 def _compute_threshold_matrix(

--- a/src/risk/network/graph/_stats.py
+++ b/src/risk/network/graph/_stats.py
@@ -14,7 +14,7 @@ def calculate_significance_matrices(
     enrichment_pvals: np.ndarray,
     tail: str = "right",
     pval_cutoff: float = 0.05,
-    fdr_cutoff: float = 0.05,
+    fdr_cutoff: float = 1.0,
 ) -> Dict[str, Any]:
     """
     Calculate significance matrices based on p-values and specified tail.
@@ -24,43 +24,30 @@ def calculate_significance_matrices(
         enrichment_pvals (np.ndarray): Matrix of enrichment p-values.
         tail (str, optional): The tail type for significance selection ('left', 'right', 'both'). Defaults to 'right'.
         pval_cutoff (float, optional): Cutoff for p-value significance. Defaults to 0.05.
-        fdr_cutoff (float, optional): Cutoff for FDR significance if applied. Defaults to 0.05.
+        fdr_cutoff (float, optional): Cutoff for FDR significance. BH q-values are always computed;
+            this only thresholds them. Since q-values are bounded by 1.0, a cutoff of 1.0 computes
+            q-values without excluding anything based on FDR. Defaults to 1.0.
 
     Returns:
         Dict[str, Any]: Dictionary containing the enrichment matrix, binary significance matrix,
             matrix of significant enrichment values, FDR-corrected q-value matrices, and the
             enrichment/depletion selection mask.
     """
-    if fdr_cutoff < 1.0:
-        # Apply FDR correction to depletion p-values
-        depletion_qvals = np.apply_along_axis(fdrcorrection, 1, depletion_pvals)[:, 1, :]
-        depletion_alpha_threshold_matrix = _compute_threshold_matrix(
-            depletion_pvals, depletion_qvals, pval_cutoff=pval_cutoff, fdr_cutoff=fdr_cutoff
-        )
-        # Compute the depletion matrix using both q-values and p-values
-        depletion_matrix = (depletion_qvals**2) * (depletion_pvals**0.5)
+    # Apply FDR correction to depletion p-values
+    depletion_qvals = np.apply_along_axis(fdrcorrection, 1, depletion_pvals)[:, 1, :]
+    depletion_alpha_threshold_matrix = _compute_threshold_matrix(
+        depletion_pvals, depletion_qvals, pval_cutoff=pval_cutoff, fdr_cutoff=fdr_cutoff
+    )
+    # Compute the depletion matrix using both q-values and p-values
+    depletion_matrix = (depletion_qvals**2) * (depletion_pvals**0.5)
 
-        # Apply FDR correction to enrichment p-values
-        enrichment_qvals = np.apply_along_axis(fdrcorrection, 1, enrichment_pvals)[:, 1, :]
-        enrichment_alpha_threshold_matrix = _compute_threshold_matrix(
-            enrichment_pvals, enrichment_qvals, pval_cutoff=pval_cutoff, fdr_cutoff=fdr_cutoff
-        )
-        # Compute the enrichment matrix using both q-values and p-values
-        enrichment_matrix = (enrichment_pvals**0.5) * (enrichment_qvals**2)
-    else:
-        # Compute threshold matrices based on p-value cutoffs only
-        depletion_alpha_threshold_matrix = _compute_threshold_matrix(
-            depletion_pvals, pval_cutoff=pval_cutoff
-        )
-        depletion_matrix = depletion_pvals
-        # No FDR correction is applied in this mode, so no q-values exist to report
-        depletion_qvals = None
-
-        enrichment_alpha_threshold_matrix = _compute_threshold_matrix(
-            enrichment_pvals, pval_cutoff=pval_cutoff
-        )
-        enrichment_matrix = enrichment_pvals
-        enrichment_qvals = None
+    # Apply FDR correction to enrichment p-values
+    enrichment_qvals = np.apply_along_axis(fdrcorrection, 1, enrichment_pvals)[:, 1, :]
+    enrichment_alpha_threshold_matrix = _compute_threshold_matrix(
+        enrichment_pvals, enrichment_qvals, pval_cutoff=pval_cutoff, fdr_cutoff=fdr_cutoff
+    )
+    # Compute the enrichment matrix using both q-values and p-values
+    enrichment_matrix = (enrichment_pvals**0.5) * (enrichment_qvals**2)
 
     # Floor exact zeros to avoid infinities from -log10(0) in downstream magnitude scaling.
     p_floor = np.finfo(float).eps

--- a/src/risk/network/graph/api.py
+++ b/src/risk/network/graph/api.py
@@ -36,7 +36,7 @@ class GraphAPI:
         stats_results: Dict[str, Any],
         tail: str = "right",
         pval_cutoff: float = 0.01,
-        fdr_cutoff: float = 0.9999,
+        fdr_cutoff: float = 1.0,
         display_prune_threshold: float = 0.0,
         linkage_criterion: str = "distance",
         linkage_method: str = "average",
@@ -54,7 +54,9 @@ class GraphAPI:
             stats_results (Dict[str, Any]): Cluster significance data.
             tail (str, optional): Type of significance tail ("right", "left", "both"). Defaults to "right".
             pval_cutoff (float, optional): p-value cutoff for significance. Defaults to 0.01.
-            fdr_cutoff (float, optional): FDR cutoff for significance. Defaults to 0.9999.
+            fdr_cutoff (float, optional): FDR cutoff for significance. BH q-values are always
+                computed; this only thresholds them. Defaults to 1.0 (permissive; excludes
+                nothing based on FDR).
             display_prune_threshold (float, optional): Display-only pruning based on spatial layout
                 distance that suppresses spatially diffuse or isolated regions in plots. Runs
                 after enrichment and clustering on plotting matrices only, does not use
@@ -238,9 +240,11 @@ class GraphAPI:
             enrichment_pvals (np.ndarray): Raw enrichment p-value matrix [node, term].
             depletion_pvals (np.ndarray): Raw depletion p-value matrix [node, term].
             enrichment_qvals (np.ndarray, optional): FDR-corrected enrichment q-value matrix
-                [node, term]. None when FDR correction was not applied.
+                [node, term]. Always populated by load_graph; None only if called directly
+                without q-values.
             depletion_qvals (np.ndarray, optional): FDR-corrected depletion q-value matrix
-                [node, term]. None when FDR correction was not applied.
+                [node, term]. Always populated by load_graph; None only if called directly
+                without q-values.
             enrichment_selection_matrix (np.ndarray): Boolean matrix [node, term] indicating
                 whether the enrichment (True) or depletion (False) tail was selected for that cell.
 
@@ -248,8 +252,8 @@ class GraphAPI:
             Tuple[Dict[int, Dict[int, List[str]]], Dict[int, Dict[int, float]], Dict[int, Dict[int, Union[float, None]]]]:
                 - Node ID to domain ID to the list of contributing term strings.
                 - Node ID to domain ID to the raw p-value paired to the strongest contributing term.
-                - Node ID to domain ID to the raw FDR paired to that same term, or None when FDR
-                  correction was not applied.
+                - Node ID to domain ID to the raw FDR paired to that same term, numeric under
+                  normal load_graph usage; None only if called directly without q-values.
         """
         node_domain_terms: Dict[int, Dict[int, List[str]]] = {}
         node_domain_pvals: Dict[int, Dict[int, float]] = {}

--- a/src/risk/network/graph/api.py
+++ b/src/risk/network/graph/api.py
@@ -4,9 +4,10 @@ risk/network/graph/api
 """
 
 import copy
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import networkx as nx
+import numpy as np
 import pandas as pd
 
 from ...annotation import define_top_annotation
@@ -127,7 +128,7 @@ class GraphAPI:
         # Extract the significant significance matrix from the processed_clusters data
         significant_clusters_significance = processed_clusters["significant_significance_matrix"]
         # Define domains in the network using the specified clustering settings
-        domains = define_domains(
+        domains, contributing_terms = define_domains(
             top_annotation=top_annotation,
             significant_clusters_significance=significant_clusters_significance,
             linkage_criterion=linkage_criterion,
@@ -141,6 +142,18 @@ class GraphAPI:
             top_annotation=top_annotation,
             min_cluster_size=min_cluster_size,
             max_cluster_size=max_cluster_size,
+        )
+
+        # Resolve each node-domain association's contributing terms and paired raw statistics
+        node_domain_terms, node_domain_pvals, node_domain_fdrs = (
+            self._resolve_node_domain_provenance(
+                contributing_terms=contributing_terms,
+                enrichment_pvals=stats_results["enrichment_pvals"],
+                depletion_pvals=stats_results["depletion_pvals"],
+                enrichment_qvals=significant_clusters["enrichment_qvals"],
+                depletion_qvals=significant_clusters["depletion_qvals"],
+                enrichment_selection_matrix=significant_clusters["enrichment_selection_matrix"],
+            )
         )
 
         # Prepare node mapping and significance sums for the final Graph object
@@ -157,6 +170,9 @@ class GraphAPI:
             trimmed_domains=trimmed_domains,
             node_label_to_node_id_map=node_label_to_id,
             node_significance_sums=node_significance_sums,
+            node_domain_terms=node_domain_terms,
+            node_domain_pvals=node_domain_pvals,
+            node_domain_fdrs=node_domain_fdrs,
         )
 
     def _define_top_annotation(
@@ -197,3 +213,63 @@ class GraphAPI:
             min_cluster_size=min_cluster_size,
             max_cluster_size=max_cluster_size,
         )
+
+    def _resolve_node_domain_provenance(
+        self,
+        contributing_terms: Dict[int, Dict[int, List[Tuple[int, str, float]]]],
+        enrichment_pvals: np.ndarray,
+        depletion_pvals: np.ndarray,
+        enrichment_qvals: Union[np.ndarray, None],
+        depletion_qvals: Union[np.ndarray, None],
+        enrichment_selection_matrix: np.ndarray,
+    ) -> Tuple[
+        Dict[int, Dict[int, List[str]]],
+        Dict[int, Dict[int, float]],
+        Dict[int, Dict[int, Union[float, None]]],
+    ]:
+        """
+        Resolve each node-domain association's contributing terms and pair the strongest term
+        with its raw p-value and FDR.
+
+        Args:
+            contributing_terms (Dict[int, Dict[int, List[Tuple[int, str, float]]]]): Node ID to
+                domain ID to a list of (term index, term string, masked significance) tuples,
+                sorted descending by absolute significance.
+            enrichment_pvals (np.ndarray): Raw enrichment p-value matrix [node, term].
+            depletion_pvals (np.ndarray): Raw depletion p-value matrix [node, term].
+            enrichment_qvals (np.ndarray, optional): FDR-corrected enrichment q-value matrix
+                [node, term]. None when FDR correction was not applied.
+            depletion_qvals (np.ndarray, optional): FDR-corrected depletion q-value matrix
+                [node, term]. None when FDR correction was not applied.
+            enrichment_selection_matrix (np.ndarray): Boolean matrix [node, term] indicating
+                whether the enrichment (True) or depletion (False) tail was selected for that cell.
+
+        Returns:
+            Tuple[Dict[int, Dict[int, List[str]]], Dict[int, Dict[int, float]], Dict[int, Dict[int, Union[float, None]]]]:
+                - Node ID to domain ID to the list of contributing term strings.
+                - Node ID to domain ID to the raw p-value paired to the strongest contributing term.
+                - Node ID to domain ID to the raw FDR paired to that same term, or None when FDR
+                  correction was not applied.
+        """
+        node_domain_terms: Dict[int, Dict[int, List[str]]] = {}
+        node_domain_pvals: Dict[int, Dict[int, float]] = {}
+        node_domain_fdrs: Dict[int, Dict[int, Union[float, None]]] = {}
+        for node_id, domain_terms in contributing_terms.items():
+            for domain_id, terms in domain_terms.items():
+                # terms is already sorted descending, so the strongest term is always first
+                strongest_term_idx, _, _ = terms[0]
+                is_enrichment = bool(enrichment_selection_matrix[node_id, strongest_term_idx])
+                pvals = enrichment_pvals if is_enrichment else depletion_pvals
+                qvals = enrichment_qvals if is_enrichment else depletion_qvals
+
+                node_domain_terms.setdefault(node_id, {})[domain_id] = [
+                    term_str for _, term_str, _ in terms
+                ]
+                node_domain_pvals.setdefault(node_id, {})[domain_id] = float(
+                    pvals[node_id, strongest_term_idx]
+                )
+                node_domain_fdrs.setdefault(node_id, {})[domain_id] = (
+                    float(qvals[node_id, strongest_term_idx]) if qvals is not None else None
+                )
+
+        return node_domain_terms, node_domain_pvals, node_domain_fdrs

--- a/src/risk/network/graph/graph.py
+++ b/src/risk/network/graph/graph.py
@@ -52,7 +52,8 @@ class Graph:
             node_domain_pvals (Dict[int, Dict[int, float]], optional): Raw p-value paired to each node's
                 strongest contributing term per domain. Defaults to None.
             node_domain_fdrs (Dict[int, Dict[int, Union[float, None]]], optional): Raw FDR paired to the
-                same term as node_domain_pvals, or None when FDR correction was not applied. Defaults to None.
+                same term as node_domain_pvals. Numeric under normal load_graph usage; None only
+                for direct construction with incomplete or omitted metadata. Defaults to None.
         """
         # Initialize self.network downstream of the other attributes
         # All public attributes can be accessed after initialization
@@ -219,7 +220,8 @@ class Graph:
             node_domain_pvals (Dict[int, Dict[int, float]], optional): Raw p-value paired to each node's
                 strongest contributing term per domain. Defaults to None.
             node_domain_fdrs (Dict[int, Dict[int, Union[float, None]]], optional): Raw FDR paired to the
-                same term as node_domain_pvals, or None when FDR correction was not applied. Defaults to None.
+                same term as node_domain_pvals. Numeric under normal load_graph usage; None only
+                for direct construction with incomplete or omitted metadata. Defaults to None.
 
         Returns:
             Dict[int, Dict]: A dictionary keyed by node ID whose values contain 'domains' holding the list

--- a/src/risk/network/graph/graph.py
+++ b/src/risk/network/graph/graph.py
@@ -4,7 +4,7 @@ risk/network/graph/graph
 """
 
 from collections import defaultdict
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 import networkx as nx
 import numpy as np
@@ -32,6 +32,9 @@ class Graph:
         trimmed_domains: pd.DataFrame,
         node_label_to_node_id_map: Dict[str, Any],
         node_significance_sums: np.ndarray,
+        node_domain_terms: Union[Dict[int, Dict[int, List[str]]], None] = None,
+        node_domain_pvals: Union[Dict[int, Dict[int, float]], None] = None,
+        node_domain_fdrs: Union[Dict[int, Dict[int, Union[float, None]]], None] = None,
     ):
         """
         Initialize the Graph object.
@@ -44,6 +47,12 @@ class Graph:
             trimmed_domains (pd.DataFrame): DataFrame containing trimmed domain data for the network nodes.
             node_label_to_node_id_map (Dict[str, Any]): A dictionary mapping node labels to their corresponding IDs.
             node_significance_sums (np.ndarray): Array containing the significant sums for the nodes.
+            node_domain_terms (Dict[int, Dict[int, List[str]]], optional): Nonzero contributing annotation
+                terms per node and domain, sorted descending by absolute significance. Defaults to None.
+            node_domain_pvals (Dict[int, Dict[int, float]], optional): Raw p-value paired to each node's
+                strongest contributing term per domain. Defaults to None.
+            node_domain_fdrs (Dict[int, Dict[int, Union[float, None]]], optional): Raw FDR paired to the
+                same term as node_domain_pvals, or None when FDR correction was not applied. Defaults to None.
         """
         # Initialize self.network downstream of the other attributes
         # All public attributes can be accessed after initialization
@@ -55,7 +64,9 @@ class Graph:
             trimmed_domains
         )
         self.node_id_to_domain_ids_and_significance_map = (
-            self._create_node_id_to_domain_ids_and_significances(domains)
+            self._create_node_id_to_domain_ids_and_significances(
+                domains, node_domain_terms, node_domain_pvals, node_domain_fdrs
+            )
         )
         self.node_id_to_node_label_map = {v: k for k, v in node_label_to_node_id_map.items()}
         self.node_label_to_significance_map = dict(
@@ -107,6 +118,10 @@ class Graph:
             if domain_id in domain_info["domains"]:
                 domain_info["domains"].remove(domain_id)
                 domain_info["significances"].pop(domain_id)
+                # Provenance dicts may be empty in degraded construction cases, so pop safely
+                domain_info["terms"].pop(domain_id, None)
+                domain_info["p_values"].pop(domain_id, None)
+                domain_info["fdrs"].pop(domain_id, None)
 
         self.summary.clear_cache()
         return node_labels
@@ -187,7 +202,11 @@ class Graph:
         return domain_info_map
 
     def _create_node_id_to_domain_ids_and_significances(
-        self, domains: pd.DataFrame
+        self,
+        domains: pd.DataFrame,
+        node_domain_terms: Union[Dict[int, Dict[int, List[str]]], None] = None,
+        node_domain_pvals: Union[Dict[int, Dict[int, float]], None] = None,
+        node_domain_fdrs: Union[Dict[int, Dict[int, Union[float, None]]], None] = None,
     ) -> Dict[int, Dict]:
         """
         Create a mapping from each node ID to its significant domains and scores.
@@ -195,12 +214,24 @@ class Graph:
         Args:
             domains (pd.DataFrame): A DataFrame containing domain information for each node. Assumes the last
                 two columns are 'all domains' and 'primary domain', which are excluded from processing.
+            node_domain_terms (Dict[int, Dict[int, List[str]]], optional): Nonzero contributing annotation
+                terms per node and domain, sorted descending by absolute significance. Defaults to None.
+            node_domain_pvals (Dict[int, Dict[int, float]], optional): Raw p-value paired to each node's
+                strongest contributing term per domain. Defaults to None.
+            node_domain_fdrs (Dict[int, Dict[int, Union[float, None]]], optional): Raw FDR paired to the
+                same term as node_domain_pvals, or None when FDR correction was not applied. Defaults to None.
 
         Returns:
-            Dict[int, Dict]: A dictionary keyed by node ID whose values contain two entries:
-                'domains' holding the list of domain columns with non-zero significance and
-                'significances' storing the corresponding scores.
+            Dict[int, Dict]: A dictionary keyed by node ID whose values contain 'domains' holding the list
+                of domain columns with non-zero significance, 'significances' storing the corresponding
+                scores, 'terms' storing each domain's nonzero contributing term strings, and 'p_values'/
+                'fdrs' storing the raw statistics paired to the strongest contributing term. The latter
+                three are representative provenance for the domain association, not a node-level test.
         """
+        # Normalize optional provenance inputs once so every node entry can be built the same way
+        node_domain_terms = node_domain_terms or {}
+        node_domain_pvals = node_domain_pvals or {}
+        node_domain_fdrs = node_domain_fdrs or {}
         # Initialize an empty dictionary to store the result
         node_id_to_domain_ids_and_significances = {}
         # Get the list of domain columns (excluding 'all domains' and 'primary domain')
@@ -213,10 +244,19 @@ class Graph:
             all_domains = domain_columns[row[domain_columns].abs() > 0].tolist()
             # Get the significance values for those domains
             significance_values = row[all_domains].to_dict()
+            # Under tail="both", a domain's per-term contributions can cancel to a net-zero sum
+            # even though individual terms are nonzero; filter to all_domains so every sibling
+            # key below stays aligned with 'domains'/'significances'.
+            node_terms = node_domain_terms.get(idx, {})
+            node_pvals = node_domain_pvals.get(idx, {})
+            node_fdrs = node_domain_fdrs.get(idx, {})
             # Store the result in the dictionary with index as the key
             node_id_to_domain_ids_and_significances[idx] = {
                 "domains": all_domains,  # The column names where significance > 0
                 "significances": significance_values,  # The actual significance values for those columns
+                "terms": {d: node_terms[d] for d in all_domains if d in node_terms},
+                "p_values": {d: node_pvals[d] for d in all_domains if d in node_pvals},
+                "fdrs": {d: node_fdrs[d] for d in all_domains if d in node_fdrs},
             }
 
         return node_id_to_domain_ids_and_significances

--- a/tests/test_load_graph.py
+++ b/tests/test_load_graph.py
@@ -10,6 +10,8 @@ import pytest
 
 from risk.cluster import define_domains
 from risk.network.graph._summary import Summary
+from risk.network.graph.api import GraphAPI
+from risk.network.graph.graph import Graph
 
 
 def test_load_graph_with_json_annotation(risk_obj, cytoscape_network, json_annotation):
@@ -457,6 +459,49 @@ def test_network_graph_structure(risk_obj, cytoscape_network, json_annotation):
     assert isinstance(
         graph.node_id_to_domain_ids_and_significance_map, dict
     ), "Node ID to domain IDs and significance map should be a dictionary"
+
+    # Every node entry should carry the additive provenance keys alongside the existing ones
+    found_provenance = False
+    for node_id, domain_info in graph.node_id_to_domain_ids_and_significance_map.items():
+        assert isinstance(
+            domain_info["domains"], list
+        ), f"Node {node_id} 'domains' should be a list"
+        assert isinstance(
+            domain_info["significances"], dict
+        ), f"Node {node_id} 'significances' should be a dictionary"
+        assert isinstance(
+            domain_info["terms"], dict
+        ), f"Node {node_id} 'terms' should be a dictionary"
+        assert isinstance(
+            domain_info["p_values"], dict
+        ), f"Node {node_id} 'p_values' should be a dictionary"
+        assert isinstance(
+            domain_info["fdrs"], dict
+        ), f"Node {node_id} 'fdrs' should be a dictionary"
+
+        # The five sibling keys must describe exactly the same set of domain associations
+        domain_id_set = set(domain_info["domains"])
+        assert (
+            set(domain_info["significances"])
+            == domain_id_set
+            == set(domain_info["terms"])
+            == set(domain_info["p_values"])
+            == set(domain_info["fdrs"])
+        ), f"Node {node_id} sibling keys should describe the same domain set"
+
+        # If a domain has contributing terms, its representative p-value/FDR should be usable
+        for domain_id in domain_info["domains"]:
+            terms = domain_info["terms"].get(domain_id, [])
+            if not terms:
+                continue
+            assert all(isinstance(term, str) for term in terms)
+            assert isinstance(domain_info["p_values"][domain_id], float)
+            assert domain_info["fdrs"][domain_id] is None or isinstance(
+                domain_info["fdrs"][domain_id], float
+            )
+            found_provenance = True
+    assert found_provenance, "Expected at least one node-domain association with contributing terms"
+
     assert isinstance(
         graph.node_id_to_node_label_map, dict
     ), "Node ID to node label map should be a dictionary"
@@ -638,6 +683,15 @@ def test_pop_domain(graph):
         assert domain_id_to_remove not in domain_info.get(
             "significances", {}
         ), f"{domain_id_to_remove} should be removed from node_id_to_domain_ids_and_significance_map['significances']"
+        assert domain_id_to_remove not in domain_info.get(
+            "terms", {}
+        ), f"{domain_id_to_remove} should be removed from node_id_to_domain_ids_and_significance_map['terms']"
+        assert domain_id_to_remove not in domain_info.get(
+            "p_values", {}
+        ), f"{domain_id_to_remove} should be removed from node_id_to_domain_ids_and_significance_map['p_values']"
+        assert domain_id_to_remove not in domain_info.get(
+            "fdrs", {}
+        ), f"{domain_id_to_remove} should be removed from node_id_to_domain_ids_and_significance_map['fdrs']"
 
     # Finally, check that the summary no longer contains the removed domain ID
     refreshed_summary = graph.summary.load()
@@ -854,27 +908,29 @@ def test_define_domains_handles_safeguard_row_drop_without_global_fallback():
     domain, while non-significant annotations remain unassigned (domain 0).
     """
     # Two significant annotations: one degenerate (zero-variance) and one clusterable.
+    # term_d and term_e are non-significant, like term_c, so they share domain 0 with it -
+    # this lets the same node/domain pair also exercise zero-filtering and abs-value sorting.
     top_annotation = pd.DataFrame(
         {
-            "significant_annotation": [True, True, False],
-            "full_terms": ["term_a", "term_b", "term_c"],
-            "significant_cluster_significance_sums": [1.0, 2.0, 0.0],
-            "significant_significance_score": [1.0, 2.0, 0.0],
+            "significant_annotation": [True, True, False, False, False],
+            "full_terms": ["term_a", "term_b", "term_c", "term_d", "term_e"],
+            "significant_cluster_significance_sums": [1.0, 2.0, 0.0, 0.0, 0.0],
+            "significant_significance_score": [1.0, 2.0, 0.0, 0.0, 0.0],
         },
-        index=["term_a", "term_b", "term_c"],
+        index=["term_a", "term_b", "term_c", "term_d", "term_e"],
     )
-    # term_a is dropped by safeguard (constant column), term_b is retained, term_c is non-significant.
+    # term_a is dropped by safeguard (constant column), term_b is retained, term_c/d/e are non-significant.
     significant_clusters_significance = np.array(
         [
-            [5.0, 1.0, 0.0],
-            [5.0, 2.0, 0.0],
-            [5.0, 3.0, 0.0],
-            [5.0, 4.0, 0.0],
+            [5.0, 1.0, 0.0, -6.0, 3.0],
+            [5.0, 2.0, 0.0, 0.0, 0.0],
+            [5.0, 3.0, 0.0, 0.0, 0.0],
+            [5.0, 4.0, 0.0, 0.0, 0.0],
         ],
         dtype=float,
     )
 
-    domains = define_domains(
+    domains, contributing_terms = define_domains(
         top_annotation=top_annotation,
         significant_clusters_significance=significant_clusters_significance,
         linkage_criterion="distance",
@@ -888,6 +944,135 @@ def test_define_domains_handles_safeguard_row_drop_without_global_fallback():
     assert top_annotation.loc["term_b", "domain"] > 0
     assert top_annotation.loc["term_a", "domain"] != top_annotation.loc["term_b", "domain"]
     assert (domains["primary_domain"] > 0).any()
+
+    # contributing_terms should carry the same node/domain provenance that fed the summation
+    assert isinstance(contributing_terms, dict)
+    domain_a_id = top_annotation.loc["term_a", "domain"]
+    domain_b_id = top_annotation.loc["term_b", "domain"]
+    assert contributing_terms[0][domain_a_id] == [("term_a", "term_a", 5.0)]
+    assert contributing_terms[0][domain_b_id] == [("term_b", "term_b", 1.0)]
+
+    # Domain 0 (term_c=0.0, term_d=-6.0, term_e=3.0 for node 0) exercises, through the same
+    # public entry point: zero-value exclusion, term string/index preservation, and descending
+    # sort by absolute masked contribution regardless of sign.
+    assert contributing_terms[0][0] == [("term_d", "term_d", -6.0), ("term_e", "term_e", 3.0)]
+
+
+def test_resolve_node_domain_provenance_pairs_selected_tail():
+    """
+    Ensure representative p-values/FDRs are read from the tail actually selected per cell,
+    not always from enrichment regardless of enrichment_selection_matrix.
+    """
+    contributing_terms = {0: {1: [(0, "term_a", 5.0)], 2: [(1, "term_b", 3.0)]}}
+    enrichment_pvals = np.array([[0.01, 0.99]])
+    depletion_pvals = np.array([[0.88, 0.02]])
+    enrichment_qvals = np.array([[0.11, 0.98]])
+    depletion_qvals = np.array([[0.77, 0.12]])
+    # Domain 1's strongest term is enrichment-selected; domain 2's is depletion-selected
+    enrichment_selection_matrix = np.array([[True, False]])
+
+    _, node_domain_pvals, node_domain_fdrs = GraphAPI()._resolve_node_domain_provenance(
+        contributing_terms=contributing_terms,
+        enrichment_pvals=enrichment_pvals,
+        depletion_pvals=depletion_pvals,
+        enrichment_qvals=enrichment_qvals,
+        depletion_qvals=depletion_qvals,
+        enrichment_selection_matrix=enrichment_selection_matrix,
+    )
+
+    assert np.isclose(node_domain_pvals[0][1], 0.01, atol=1e-12, rtol=0.0)
+    assert np.isclose(node_domain_fdrs[0][1], 0.11, atol=1e-12, rtol=0.0)
+    assert np.isclose(node_domain_pvals[0][2], 0.02, atol=1e-12, rtol=0.0)
+    assert np.isclose(node_domain_fdrs[0][2], 0.12, atol=1e-12, rtol=0.0)
+
+
+def test_graph_construction_without_node_domain_metadata_defaults_empty():
+    """
+    Ensure direct Graph construction without the new provenance arguments degrades safely,
+    and that pop() does not crash when those provenance dictionaries are empty.
+    """
+    network = nx.Graph()
+    network.add_nodes_from([0, 1])
+    network.add_edge(0, 1)
+    for node in network.nodes:
+        network.nodes[node]["x"] = 0.0
+        network.nodes[node]["y"] = 0.0
+        network.nodes[node]["label"] = str(node)
+
+    domains = pd.DataFrame(
+        {1: [5.0, 0.0], "all_domains": [[1], []], "primary_domain": [1, 0]},
+        index=[0, 1],
+    )
+    trimmed_domains = pd.DataFrame(
+        {
+            "normalized_description": ["term_a"],
+            "full_descriptions": [("term_a",)],
+            "significance_scores": [(5.0,)],
+        },
+        index=[1],
+    )
+
+    graph = Graph(
+        network=network,
+        annotation={},
+        stats_results={},
+        domains=domains,
+        trimmed_domains=trimmed_domains,
+        node_label_to_node_id_map={"0": 0, "1": 1},
+        node_significance_sums=np.array([5.0, 0.0]),
+    )
+
+    for domain_info in graph.node_id_to_domain_ids_and_significance_map.values():
+        assert domain_info["terms"] == {}
+        assert domain_info["p_values"] == {}
+        assert domain_info["fdrs"] == {}
+
+    # pop() must not raise even though the provenance dictionaries are empty
+    graph.pop(1)
+
+
+def test_graph_excludes_zero_significance_domain_from_provenance():
+    """
+    Ensure a domain with zero summed significance (absent from 'domains') is also excluded
+    from 'terms'/'p_values'/'fdrs', even when upstream provenance still references it. This can
+    happen under tail="both", where a domain's per-term contributions can cancel to a net-zero
+    sum despite individual terms being nonzero.
+    """
+    network = nx.Graph()
+    network.add_node(0)
+    network.nodes[0]["x"] = 0.0
+    network.nodes[0]["y"] = 0.0
+    network.nodes[0]["label"] = "0"
+
+    # Domain 1 has zero summed significance for node 0, so it is absent from all_domains.
+    domains = pd.DataFrame(
+        {1: [0.0], "all_domains": [[]], "primary_domain": [0]},
+        index=[0],
+    )
+    trimmed_domains = pd.DataFrame(
+        {"normalized_description": [], "full_descriptions": [], "significance_scores": []},
+        index=pd.Index([], dtype=int),
+    )
+
+    graph = Graph(
+        network=network,
+        annotation={},
+        stats_results={},
+        domains=domains,
+        trimmed_domains=trimmed_domains,
+        node_label_to_node_id_map={"0": 0},
+        node_significance_sums=np.array([0.0]),
+        # Provenance still references domain 1 despite its summed significance being zero
+        node_domain_terms={0: {1: ["term_a", "term_b"]}},
+        node_domain_pvals={0: {1: 0.01}},
+        node_domain_fdrs={0: {1: 0.02}},
+    )
+
+    entry = graph.node_id_to_domain_ids_and_significance_map[0]
+    assert entry["domains"] == []
+    assert 1 not in entry["terms"]
+    assert 1 not in entry["p_values"]
+    assert 1 not in entry["fdrs"]
 
 
 def _validate_graph(graph):

--- a/tests/test_load_graph.py
+++ b/tests/test_load_graph.py
@@ -527,6 +527,67 @@ def test_network_graph_structure(risk_obj, cytoscape_network, json_annotation):
     assert isinstance(graph.summary, Summary), "Summary should be a Summary object"
 
 
+def test_load_graph_threads_fdr_values_into_node_domain_metadata(
+    risk_obj, cytoscape_network, json_annotation
+):
+    """
+    Ensure a real load_graph(...) run with FDR correction enabled (fdr_cutoff < 1.0) threads a
+    genuine, non-None float FDR value into node_id_to_domain_ids_and_significance_map. This
+    guards against a plumbing regression where q-values are computed but never reach Graph.
+
+    Args:
+        risk_obj: The RISK object instance used for loading clusters and graphs.
+        cytoscape_network: The network object to be used for cluster and graph generation.
+        json_annotation: The JSON annotation associated with the network.
+    """
+    # === Cluster and Stats ===
+    clusters = risk_obj.cluster_leiden(
+        network=cytoscape_network,
+        fraction_shortest_edges=0.75,
+        resolution=1.0,
+        random_seed=887,
+    )
+    stats_results = risk_obj.run_permutation(
+        annotation=json_annotation,
+        clusters=clusters,
+        null_distribution="network",
+        score_metric="stdev",
+        num_permutations=20,
+        random_seed=887,
+        max_workers=1,
+    )
+    # fdr_cutoff < 1.0 (the load_graph default) enables real FDR correction, unlike the
+    # fdr_cutoff=1.0 used elsewhere in this file.
+    graph = risk_obj.load_graph(
+        network=cytoscape_network,
+        annotation=json_annotation,
+        stats_results=stats_results,
+        tail="right",
+        pval_cutoff=0.05,
+        fdr_cutoff=0.9999,
+        display_prune_threshold=0.1,
+        linkage_criterion="distance",
+        linkage_method="average",
+        linkage_metric="yule",
+        linkage_threshold=0.2,
+        min_cluster_size=5,
+        max_cluster_size=1000,
+    )
+
+    found_float_fdr = False
+    for domain_info in graph.node_id_to_domain_ids_and_significance_map.values():
+        for domain_id, fdr in domain_info["fdrs"].items():
+            if fdr is None:
+                continue
+            assert isinstance(fdr, float)
+            assert domain_id in domain_info["domains"]
+            assert domain_id in domain_info["significances"]
+            assert domain_id in domain_info["terms"]
+            assert domain_id in domain_info["p_values"]
+            found_float_fdr = True
+    assert found_float_fdr, "Expected at least one non-None float FDR under fdr_cutoff < 1.0"
+
+
 def test_load_graph_summary(graph):
     """
     Test loading the graph summary with predefined parameters.

--- a/tests/test_load_graph.py
+++ b/tests/test_load_graph.py
@@ -496,9 +496,9 @@ def test_network_graph_structure(risk_obj, cytoscape_network, json_annotation):
                 continue
             assert all(isinstance(term, str) for term in terms)
             assert isinstance(domain_info["p_values"][domain_id], float)
-            assert domain_info["fdrs"][domain_id] is None or isinstance(
-                domain_info["fdrs"][domain_id], float
-            )
+            # BH q-values are always computed regardless of fdr_cutoff, so this fixture's
+            # fdr_cutoff=1.0 (permissive threshold) still yields a real numeric FDR.
+            assert isinstance(domain_info["fdrs"][domain_id], float)
             found_provenance = True
     assert found_provenance, "Expected at least one node-domain association with contributing terms"
 
@@ -531,8 +531,9 @@ def test_load_graph_threads_fdr_values_into_node_domain_metadata(
     risk_obj, cytoscape_network, json_annotation
 ):
     """
-    Ensure a real load_graph(...) run with FDR correction enabled (fdr_cutoff < 1.0) threads a
-    genuine, non-None float FDR value into node_id_to_domain_ids_and_significance_map. This
+    Ensure a real load_graph(...) run threads a genuine, numeric FDR value into
+    node_id_to_domain_ids_and_significance_map, even at the permissive default fdr_cutoff=1.0.
+    BH q-values are always computed regardless of fdr_cutoff, which only thresholds them; this
     guards against a plumbing regression where q-values are computed but never reach Graph.
 
     Args:
@@ -556,15 +557,14 @@ def test_load_graph_threads_fdr_values_into_node_domain_metadata(
         random_seed=887,
         max_workers=1,
     )
-    # fdr_cutoff < 1.0 (the load_graph default) enables real FDR correction, unlike the
-    # fdr_cutoff=1.0 used elsewhere in this file.
+    # fdr_cutoff=1.0 (the load_graph default) is permissive but still computes real q-values.
     graph = risk_obj.load_graph(
         network=cytoscape_network,
         annotation=json_annotation,
         stats_results=stats_results,
         tail="right",
         pval_cutoff=0.05,
-        fdr_cutoff=0.9999,
+        fdr_cutoff=1.0,
         display_prune_threshold=0.1,
         linkage_criterion="distance",
         linkage_method="average",
@@ -585,7 +585,7 @@ def test_load_graph_threads_fdr_values_into_node_domain_metadata(
             assert domain_id in domain_info["terms"]
             assert domain_id in domain_info["p_values"]
             found_float_fdr = True
-    assert found_float_fdr, "Expected at least one non-None float FDR under fdr_cutoff < 1.0"
+    assert found_float_fdr, "Expected at least one non-None float FDR under fdr_cutoff=1.0"
 
 
 def test_load_graph_summary(graph):


### PR DESCRIPTION
This PR adds provenance metadata for node-domain associations by exposing contributing annotation terms together with representative raw p-values and FDRs for the strongest contributing term. The implementation preserves the existing API while threading provenance through graph construction, standardizing FDR computation semantics, updating the graph metadata structure, increasing the package version to v0.1.5, and expanding the test suite to cover provenance propagation, FDR handling, and backward compatibility.