### PR TITLE
v0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,17 @@ description = "A Python package for scalable network analysis and high-quality v
 authors = [
     { name = "Ira Horecka", email = "ira89@icloud.com" },
 ]
+keywords = [
+    "bioinformatics",
+    "network-analysis",
+    "systems-biology",
+    "community-detection",
+    "graph-clustering",
+    "enrichment-analysis",
+    "gene-ontology",
+    "cytoscape",
+    "visualization",
+]
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "risk-network"
 dynamic = ["version"]
-description = "A Python package for scalable network analysis and high-quality visualization."
+description = "RISK (Regional Inference of Significant Kinships): a Python tool for biological network annotation, enrichment analysis, community detection, and visualization."
 authors = [
     { name = "Ira Horecka", email = "ira89@icloud.com" },
 ]
@@ -62,6 +62,7 @@ text = "GPL-3.0-or-later"
 
 [project.urls]
 Homepage = "https://github.com/riskportal/risk"
+Documentation = "https://riskportal.github.io/risk-docs/"
 Issues = "https://github.com/riskportal/risk/issues"
 
 [tool.setuptools]

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -9,4 +9,4 @@ A next-generation tool for biological network annotation and visualization
 from .risk import RISK
 
 __all__ = ["RISK"]
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/src/risk/cluster/label.py
+++ b/src/risk/cluster/label.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from numpy.linalg import LinAlgError
 from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import pdist, squareform
 from sklearn.metrics import silhouette_score
 from tqdm import tqdm
 
@@ -459,74 +460,62 @@ def _find_best_silhouette_score(
     m: np.ndarray,
     linkage_metric: str,
     linkage_criterion: str,
-    lower_bound: float = 0.001,
-    upper_bound: float = 1.0,
 ) -> Tuple[float, float]:
     """
-    Find the best silhouette score using binary search.
+    Find the best silhouette score via discrete enumeration over linkage merge heights.
 
     Args:
         Z (np.ndarray): Linkage matrix.
         m (np.ndarray): Data matrix.
         linkage_metric (str): Linkage metric for silhouette score calculation.
         linkage_criterion (str): Clustering criterion.
-        lower_bound (float, optional): Lower bound for search. Defaults to 0.001.
-        upper_bound (float, optional): Upper bound for search. Defaults to 1.0.
 
     Returns:
         Tuple[float, float]:
-            - Best threshold (float): The threshold that yields the best silhouette score.
+            - Best threshold (float): Normalized fraction in (0, 1] of the merge height that
+              yields the best silhouette score.
             - Best silhouette score (float): The highest silhouette score achieved.
+
+    Raises:
+        ValueError: If no candidate merge height yields a scoreable partition (requires
+            2 to N-1 clusters).
     """
+    # fcluster(..., criterion="distance") only changes partition at actual merge heights, so
+    # the silhouette-vs-threshold objective is a stepwise, often multimodal function of the
+    # cut height. Binary search assumes unimodality between two probed endpoints and can
+    # converge on a suboptimal cut; enumerating the true candidate heights cannot miss the
+    # best partition. This is slower at large N (O(N) candidates vs. a fixed probe budget),
+    # but searches the actual space the objective lives on.
+    raw_max = np.max(Z[:, 2])
+    n = m.shape[0]
+    dist_matrix = squareform(pdist(m, metric=linkage_metric))
+
     best_score = -np.inf
-    best_threshold = None
-    minimum_linkage_threshold = 1e-6
-
-    # Test lower bound
-    max_d_lower = np.max(Z[:, 2]) * lower_bound
-    clusters_lower = fcluster(Z, max_d_lower, criterion=linkage_criterion)
-    try:
-        score_lower = silhouette_score(m, clusters_lower, metric=linkage_metric)
-    except ValueError:
-        score_lower = -np.inf
-
-    # Test upper bound
-    max_d_upper = np.max(Z[:, 2]) * upper_bound
-    clusters_upper = fcluster(Z, max_d_upper, criterion=linkage_criterion)
-    try:
-        score_upper = silhouette_score(m, clusters_upper, metric=linkage_metric)
-    except ValueError:
-        score_upper = -np.inf
-
-    # Determine initial bounds for binary search
-    if score_lower > score_upper:
-        best_score = score_lower
-        best_threshold = lower_bound
-        upper_bound = (lower_bound + upper_bound) / 2
-    else:
-        best_score = score_upper
-        best_threshold = upper_bound
-        lower_bound = (lower_bound + upper_bound) / 2
-
-    # Binary search loop
-    while upper_bound - lower_bound > minimum_linkage_threshold:
-        mid_threshold = (upper_bound + lower_bound) / 2
-        max_d_mid = np.max(Z[:, 2]) * mid_threshold
-        clusters_mid = fcluster(Z, max_d_mid, criterion=linkage_criterion)
+    best_height = None
+    for height in np.unique(Z[:, 2]):
+        labels = fcluster(Z, height, criterion=linkage_criterion)
+        n_clusters = len(np.unique(labels))
+        if n_clusters < 2 or n_clusters >= n:
+            continue
         try:
-            score_mid = silhouette_score(m, clusters_mid, metric=linkage_metric)
+            score = silhouette_score(dist_matrix, labels, metric="precomputed")
         except ValueError:
-            score_mid = -np.inf
+            continue
 
-        # Update best score and threshold if mid-point is better
-        if score_mid > best_score:
-            best_score = score_mid
-            best_threshold = mid_threshold
+        is_better = score > best_score
+        is_tied = (
+            np.isfinite(score)
+            and np.isfinite(best_score)
+            and np.isclose(score, best_score, rtol=0.0, atol=1e-12)
+        )
+        if is_better or (is_tied and height < best_height):
+            best_score = score
+            best_height = height
 
-        # Adjust bounds based on the scores
-        if score_lower > score_upper:
-            upper_bound = mid_threshold
-        else:
-            lower_bound = mid_threshold
+    if best_height is None:
+        raise ValueError(
+            "No candidate linkage merge height yielded a scoreable silhouette partition "
+            "(requires 2 to N-1 clusters)."
+        )
 
-    return best_threshold, float(best_score)
+    return float(best_height) / float(raw_max), float(best_score)

--- a/tests/test_load_graph.py
+++ b/tests/test_load_graph.py
@@ -1024,20 +1024,30 @@ def test_define_domains_handles_safeguard_row_drop_without_global_fallback():
 
 def test_define_domains_auto_threshold_matches_best_discrete_cut():
     """
-    Ensure linkage_threshold="auto" assigns domains matching the independently computed
-    best discrete dendrogram cut, not merely a plausible one. linkage_method/linkage_metric
-    are fixed so this isolates the threshold search from method/metric auto-optimization.
-    Four well-separated blobs of four annotations each give a silhouette-vs-cut landscape
-    with a clear, unambiguous best partition to check the result against.
+    Ensure linkage_threshold="auto" assigns domains from the best discrete dendrogram cut.
+    The method and metric are fixed so this isolates threshold selection from method/metric
+    auto-optimization.
     """
-    rng = np.random.default_rng(3)
-    m = np.vstack(
+    m = np.array(
         [
-            rng.normal([0, 0], 0.05, size=(4, 2)),
-            rng.normal([2, 0], 0.05, size=(4, 2)),
-            rng.normal([0, 2], 0.05, size=(4, 2)),
-            rng.normal([2, 2], 0.05, size=(4, 2)),
-        ]
+            [0.00, 0.10, 0.20],
+            [0.05, 0.15, 0.25],
+            [-0.05, 0.05, 0.15],
+            [0.10, 0.00, 0.20],
+            [3.00, 0.00, 0.20],
+            [3.10, 0.10, 0.30],
+            [2.90, -0.10, 0.10],
+            [3.05, 0.05, 0.25],
+            [0.00, 3.00, 0.20],
+            [0.10, 3.10, 0.30],
+            [-0.10, 2.90, 0.10],
+            [0.05, 3.05, 0.25],
+            [3.00, 3.00, 0.20],
+            [3.10, 3.10, 0.30],
+            [2.90, 2.90, 0.10],
+            [3.05, 3.05, 0.25],
+        ],
+        dtype=float,
     )
     n_annotations = m.shape[0]
     term_ids = [f"term_{i}" for i in range(n_annotations)]
@@ -1050,12 +1060,10 @@ def test_define_domains_auto_threshold_matches_best_discrete_cut():
         },
         index=term_ids,
     )
-    # significant_clusters_significance has shape (n_nodes, n_annotations); define_domains
-    # reconstructs m = significant_clusters_significance[:, significant_mask].T internally,
-    # so significant_clusters_significance is simply m transposed here.
+    # define_domains clusters significant_clusters_significance.T for significant annotations.
     significant_clusters_significance = m.T
 
-    # Independently enumerate the true best discrete cut on the same matrix.
+    # Independently enumerate the best observable dendrogram cut.
     Z = linkage(m, method="average", metric="euclidean")
     dist_matrix = squareform(pdist(m, metric="euclidean"))
     best_height, best_score = None, -np.inf
@@ -1089,8 +1097,6 @@ def test_define_domains_auto_threshold_matches_best_discrete_cut():
         linkage_threshold="auto",
     )
 
-    # Compare groupings in a label-invariant way: which annotations end up together matters,
-    # not what integer domain ID they're given.
     actual_groups = set(
         frozenset(group.index) for _, group in top_annotation.groupby("domain") if group.index.size
     )
@@ -1099,11 +1105,9 @@ def test_define_domains_auto_threshold_matches_best_discrete_cut():
 
 def test_define_domains_auto_threshold_no_scoreable_partition_falls_back_to_unique_domains():
     """
-    Ensure linkage_threshold="auto" degrades gracefully at the public define_domains layer
-    when no candidate merge height yields a scoreable (2 to N-1 cluster) partition. With only
-    two significant annotations, the only possible cut is 1-vs-2 clusters, so no valid
-    silhouette partition exists; define_domains must not raise, and must still assign each
-    significant annotation its own domain rather than collapsing them together.
+    Ensure linkage_threshold="auto" degrades gracefully when no scoreable cut exists.
+    With only two significant annotations, no 2 to N-1 silhouette partition is possible, so
+    define_domains should still assign distinct domains without raising.
     """
     top_annotation = pd.DataFrame(
         {
@@ -1114,11 +1118,9 @@ def test_define_domains_auto_threshold_no_scoreable_partition_falls_back_to_uniq
         },
         index=["term_a", "term_b"],
     )
-    significant_clusters_significance = np.array(
-        [[0.0, 10.0], [0.0, 10.0], [1.0, 11.0]]
-    )  # shape (3 nodes, 2 annotations); term_a and term_b are clearly distinct rows once transposed
+    significant_clusters_significance = np.array([[0.0, 10.0], [0.0, 10.0], [1.0, 11.0]])
 
-    domains, _ = define_domains(
+    define_domains(
         top_annotation=top_annotation,
         significant_clusters_significance=significant_clusters_significance,
         linkage_criterion="distance",

--- a/tests/test_load_graph.py
+++ b/tests/test_load_graph.py
@@ -7,6 +7,9 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import pdist, squareform
+from sklearn.metrics import silhouette_score
 
 from risk.cluster import define_domains
 from risk.network.graph._summary import Summary
@@ -1017,6 +1020,118 @@ def test_define_domains_handles_safeguard_row_drop_without_global_fallback():
     # public entry point: zero-value exclusion, term string/index preservation, and descending
     # sort by absolute masked contribution regardless of sign.
     assert contributing_terms[0][0] == [("term_d", "term_d", -6.0), ("term_e", "term_e", 3.0)]
+
+
+def test_define_domains_auto_threshold_matches_best_discrete_cut():
+    """
+    Ensure linkage_threshold="auto" assigns domains matching the independently computed
+    best discrete dendrogram cut, not merely a plausible one. linkage_method/linkage_metric
+    are fixed so this isolates the threshold search from method/metric auto-optimization.
+    Four well-separated blobs of four annotations each give a silhouette-vs-cut landscape
+    with a clear, unambiguous best partition to check the result against.
+    """
+    rng = np.random.default_rng(3)
+    m = np.vstack(
+        [
+            rng.normal([0, 0], 0.05, size=(4, 2)),
+            rng.normal([2, 0], 0.05, size=(4, 2)),
+            rng.normal([0, 2], 0.05, size=(4, 2)),
+            rng.normal([2, 2], 0.05, size=(4, 2)),
+        ]
+    )
+    n_annotations = m.shape[0]
+    term_ids = [f"term_{i}" for i in range(n_annotations)]
+    top_annotation = pd.DataFrame(
+        {
+            "significant_annotation": [True] * n_annotations,
+            "full_terms": term_ids,
+            "significant_cluster_significance_sums": np.ones(n_annotations),
+            "significant_significance_score": np.ones(n_annotations),
+        },
+        index=term_ids,
+    )
+    # significant_clusters_significance has shape (n_nodes, n_annotations); define_domains
+    # reconstructs m = significant_clusters_significance[:, significant_mask].T internally,
+    # so significant_clusters_significance is simply m transposed here.
+    significant_clusters_significance = m.T
+
+    # Independently enumerate the true best discrete cut on the same matrix.
+    Z = linkage(m, method="average", metric="euclidean")
+    dist_matrix = squareform(pdist(m, metric="euclidean"))
+    best_height, best_score = None, -np.inf
+    for height in np.unique(Z[:, 2]):
+        labels = fcluster(Z, height, criterion="distance")
+        n_clusters = len(np.unique(labels))
+        if n_clusters < 2 or n_clusters >= n_annotations:
+            continue
+        score = silhouette_score(dist_matrix, labels, metric="precomputed")
+        is_tied = (
+            np.isfinite(score)
+            and np.isfinite(best_score)
+            and np.isclose(score, best_score, rtol=0.0, atol=1e-12)
+        )
+        if score > best_score or (is_tied and height < best_height):
+            best_score = score
+            best_height = height
+    assert best_height is not None
+    expected_labels = fcluster(Z, best_height, criterion="distance")
+    expected_groups = {
+        frozenset(term_ids[i] for i in range(n_annotations) if expected_labels[i] == label)
+        for label in np.unique(expected_labels)
+    }
+
+    define_domains(
+        top_annotation=top_annotation,
+        significant_clusters_significance=significant_clusters_significance,
+        linkage_criterion="distance",
+        linkage_method="average",
+        linkage_metric="euclidean",
+        linkage_threshold="auto",
+    )
+
+    # Compare groupings in a label-invariant way: which annotations end up together matters,
+    # not what integer domain ID they're given.
+    actual_groups = set(
+        frozenset(group.index) for _, group in top_annotation.groupby("domain") if group.index.size
+    )
+    assert actual_groups == expected_groups
+
+
+def test_define_domains_auto_threshold_no_scoreable_partition_falls_back_to_unique_domains():
+    """
+    Ensure linkage_threshold="auto" degrades gracefully at the public define_domains layer
+    when no candidate merge height yields a scoreable (2 to N-1 cluster) partition. With only
+    two significant annotations, the only possible cut is 1-vs-2 clusters, so no valid
+    silhouette partition exists; define_domains must not raise, and must still assign each
+    significant annotation its own domain rather than collapsing them together.
+    """
+    top_annotation = pd.DataFrame(
+        {
+            "significant_annotation": [True, True],
+            "full_terms": ["term_a", "term_b"],
+            "significant_cluster_significance_sums": [1.0, 1.0],
+            "significant_significance_score": [1.0, 1.0],
+        },
+        index=["term_a", "term_b"],
+    )
+    significant_clusters_significance = np.array(
+        [[0.0, 10.0], [0.0, 10.0], [1.0, 11.0]]
+    )  # shape (3 nodes, 2 annotations); term_a and term_b are clearly distinct rows once transposed
+
+    domains, _ = define_domains(
+        top_annotation=top_annotation,
+        significant_clusters_significance=significant_clusters_significance,
+        linkage_criterion="distance",
+        linkage_method="average",
+        linkage_metric="euclidean",
+        linkage_threshold="auto",
+    )
+
+    domain_a = top_annotation.loc["term_a", "domain"]
+    domain_b = top_annotation.loc["term_b", "domain"]
+    assert domain_a > 0
+    assert domain_b > 0
+    assert domain_a != domain_b
 
 
 def test_resolve_node_domain_provenance_pairs_selected_tail():


### PR DESCRIPTION
This PR prepares RISK v0.1.6 by improving package discoverability metadata and fixing automatic linkage-threshold selection to evaluate the discrete dendrogram merge heights directly. It also adds regression tests for optimal auto-threshold selection and graceful fallback when no silhouette-scoreable partition exists.